### PR TITLE
Add JAVA_CI_FAILURE environment variable to Telegram workflow

### DIFF
--- a/.github/workflows/telegram_comment.yml
+++ b/.github/workflows/telegram_comment.yml
@@ -22,4 +22,4 @@ jobs:
           to: ${{ secrets.CHAT_ID }}
           token: ${{ secrets.BOT_TOKEN }}
           message: |
-            '$ACTOR left a [comment]($URL) on issue #$ID ($TITLE)'
+            "$ACTOR left a [comment]($URL) on issue #$ID ($TITLE)"

--- a/.github/workflows/telegram_gradle.yml
+++ b/.github/workflows/telegram_gradle.yml
@@ -9,6 +9,7 @@ env:
     # REPO_MATCH: ${{ github.repository == 'AY2425S2-CS2113-W12-1/tp' }}
     ACTOR: ${{ github.actor }}
     JAVA_CI_SUCCESS: ${{ github.event.workflow_run.conclusion == 'success' }}
+    JAVA_CI_FAILURE: ${{ github.event.workflow_run.conclusion == 'failure' }}
 
 jobs:
   on-success:
@@ -25,7 +26,7 @@ jobs:
             $ACTOR's recent edits have passed all Java CI checks
 
   on-failure:
-    if: ${{ !github.env.JAVA_CI_SUCCESS }}
+    if: ${{ github.env.JAVA_CI_FAILURE }}
     runs-on: ubuntu-latest
     steps:
       - name: Send message to Telegram

--- a/.github/workflows/telegram_gradle.yml
+++ b/.github/workflows/telegram_gradle.yml
@@ -23,7 +23,7 @@ jobs:
           to: ${{ secrets.CHAT_ID }}
           token: ${{ secrets.BOT_TOKEN }}
           message: |
-            $ACTOR's recent edits have passed all Java CI checks
+            "$ACTOR's recent edits have passed all Java CI checks"
 
   on-failure:
     if: ${{ github.env.JAVA_CI_FAILURE }}
@@ -35,4 +35,4 @@ jobs:
           to: ${{ secrets.CHAT_ID }}
           token: ${{ secrets.BOT_TOKEN }}
           message: |
-            '$ACTOR's recent edits did not pass the Java CI checks'
+            "$ACTOR's recent edits did not pass the Java CI checks"

--- a/.github/workflows/telegram_issue.yml
+++ b/.github/workflows/telegram_issue.yml
@@ -22,4 +22,4 @@ jobs:
           to: ${{ secrets.CHAT_ID }}
           token: ${{ secrets.BOT_TOKEN }}
           message: |
-            '$ACTOR $ACTION [issue #$ID ($TITLE)]($URL)'
+            "$ACTOR $ACTION [issue #$ID ($TITLE)]($URL)"


### PR DESCRIPTION
Introduce a new environment variable to the Telegram workflow that triggers actions when the Java CI checks fail.