### PR TITLE
Disable table of contents in About Us documentation

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -2,6 +2,7 @@
 title: About Us
 layout: default
 nav_order: 4
+has_toc: false
 ---
 
 # About Us


### PR DESCRIPTION
The table of contents has been removed from the About Us documentation to streamline the content presentation.